### PR TITLE
Fix the implementation of Selector.GenerateRandomIndex()

### DIFF
--- a/RandomSelection/Selector.cs
+++ b/RandomSelection/Selector.cs
@@ -169,22 +169,40 @@ namespace BNolan.RandomSelection
                 throw new ArgumentOutOfRangeException("upperLimit");
             }
 
+            int randomIndex = 0;
             using (var randomGenerator = new RNGCryptoServiceProvider())
             {
-                byte[] uint32Buffer = new byte[sizeof(UInt32)];
-                while (true)
+                byte[] maxIndex = BitConverter.GetBytes(upperLimit);
+                int arraySize = 3;
+                for (; arraySize > 0; arraySize--)
                 {
-                    randomGenerator.GetBytes(uint32Buffer);
-                    UInt32 rand = BitConverter.ToUInt32(uint32Buffer, 0);
-
-                    Int64 max = (1 + (Int64)UInt32.MaxValue);
-                    Int64 remainder = max % upperLimit;
-                    if (rand < max - remainder)
+                    if (maxIndex[arraySize] != 0)
                     {
-                        return (Int32)(rand % upperLimit);
+                        break;
                     }
                 }
+
+                // Create the byte array used for calculating the 32bit int
+                byte[] fullIntArray = new byte[4];
+                // Create the byte array no larger than needed for the max
+                // set by the upperLimit parameter
+                byte[] randomNumber = new byte[arraySize + 1];
+                do
+                {
+                    // Reset the array to 0
+                    Array.Clear(fullIntArray, 0, fullIntArray.Length);
+                    // Get the random value
+                    randomGenerator.GetBytes(randomNumber);
+
+                    // Copy the value to an int32 sized byte array
+                    Array.Copy(randomNumber, fullIntArray, arraySize + 1);
+
+                    randomIndex = BitConverter.ToInt32(fullIntArray, 0);
+                    // Keep looping until we have a valid index
+                } while (randomIndex < 0 || randomIndex >= upperLimit);
             }
+
+            return randomIndex;
         }
 
         /// <summary>

--- a/RandomSelection/Selector.cs
+++ b/RandomSelection/Selector.cs
@@ -164,40 +164,27 @@ namespace BNolan.RandomSelection
         /// <returns>Random number from 0 to the <code>upperLimit</code></returns>
         public int GenerateRandomIndex(int upperLimit)
         {
-            int randomIndex = 0;
-            using (var randomGenerator = new RNGCryptoServiceProvider())
+            if (upperLimit <= 0)
             {
-                byte[] maxIndex = BitConverter.GetBytes(upperLimit);
-                int arraySize = 3;
-                for (; arraySize > 0; arraySize--)
-                {
-                    if (maxIndex[arraySize] != 0)
-                    {
-                        break;
-                    }
-                }
-
-                // Create the byte array used for calculating the 32bit int
-                byte[] fullIntArray = new byte[4];
-                // Create the byte array no larger than needed for the max
-                // set by the upperLimit parameter
-                byte[] randomNumber = new byte[arraySize + 1];
-                do
-                {
-                    // Reset the array to 0
-                    Array.Clear(fullIntArray, 0, fullIntArray.Length);
-                    // Get the random value
-                    randomGenerator.GetBytes(randomNumber);
-
-                    // Copy the value to an int32 sized byte array
-                    Array.Copy(randomNumber, fullIntArray, arraySize);
-
-                    randomIndex = BitConverter.ToInt32(fullIntArray, 0);
-                    // Keep looping until we have a valid index
-                } while (randomIndex < 0 || randomIndex >= upperLimit);
+                throw new ArgumentOutOfRangeException("upperLimit");
             }
 
-            return randomIndex;
+            using (var randomGenerator = new RNGCryptoServiceProvider())
+            {
+                byte[] uint32Buffer = new byte[sizeof(UInt32)];
+                while (true)
+                {
+                    randomGenerator.GetBytes(uint32Buffer);
+                    UInt32 rand = BitConverter.ToUInt32(uint32Buffer, 0);
+
+                    Int64 max = (1 + (Int64)UInt32.MaxValue);
+                    Int64 remainder = max % upperLimit;
+                    if (rand < max - remainder)
+                    {
+                        return (Int32)(rand % upperLimit);
+                    }
+                }
+            }
         }
 
         /// <summary>

--- a/Testing.Unit/SelectorTests.cs
+++ b/Testing.Unit/SelectorTests.cs
@@ -234,5 +234,43 @@ namespace Testing.Unit
              where s.UniqueId == "d"
              select s).Count().Should().Be(1);
         }
+
+        [Test]
+        public static void RandomSelectorSelectsAllElementsEventually()
+        {
+            var outputValues = new HashSet<string>();
+
+            for (int numberOfSelections = 0; numberOfSelections < 1000; numberOfSelections++)
+            {
+                var selector = new BNolan.RandomSelection.Selector<string>();
+                selector.TryAddItem("jen").Should().BeTrue();
+                selector.TryAddItem("michael").Should().BeTrue();
+                selector.TryAddItem("staci").Should().BeTrue();
+                outputValues.Add(selector.RandomSelect(1).First().Value);
+            }
+
+            outputValues.Should().Contain("jen");
+            outputValues.Should().Contain("michael");
+            outputValues.Should().Contain("staci");
+        }
+
+        [Test]
+        public static void RandomSelectorGeneratesAllIndicesEventually()
+        {
+            var outputValues = new HashSet<int>();
+
+            for (int numberOfSelections = 0; numberOfSelections < 1000; numberOfSelections++)
+            {
+                var selector = new BNolan.RandomSelection.Selector<string>();
+
+                outputValues.Add(selector.GenerateRandomIndex(5));
+            }
+
+            outputValues.Should().Contain(0);
+            outputValues.Should().Contain(1);
+            outputValues.Should().Contain(2);
+            outputValues.Should().Contain(3);
+            outputValues.Should().Contain(4);
+        }
     }
 }


### PR DESCRIPTION
Hey @bnolan001, I use RandomSelection in [AntiquesAppraisalBot](https://github.com/brickman1444/AntiqueAppraisalBot) to select the category of item to display but I was seeing one category come up way more than I expected.

I created two new unit tests in this commit to replicate simple scenarios and narrow down what was wrong. I narrowed it down to Selector.GenerateRandomIndex(someNumber) always returning 0 in my test cases. Both of the new tests failed before my changes to Selector.cs.

I didn't try to fix the existing code because I didn't fully understand what was happening in the byte arrays. Instead, I reimplemented it with a trusted solution from https://docs.microsoft.com/en-us/archive/msdn-magazine/2007/september/net-matters-tales-from-the-cryptorandom which I've seen cited in a few places for this use case. Now both new tests pass.